### PR TITLE
Non-latin text-recognition support

### DIFF
--- a/text-recognition/RNMLKitTextRecognition.podspec
+++ b/text-recognition/RNMLKitTextRecognition.podspec
@@ -22,14 +22,14 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   # To recognize Latin script
-  s.dependency 'GoogleMLKit/TextRecognition', '4.0.0'
+  s.dependency 'GoogleMLKit/TextRecognition', '2.6.0'
   # To recognize Chinese script
-  s.dependency 'GoogleMLKit/TextRecognitionChinese', '4.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionChinese', '2.6.0'
   # To recognize Devanagari script
-  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '4.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '2.6.0'
   # To recognize Japanese script
-  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '4.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '2.6.0'
   # To recognize Korean script
-  s.dependency 'GoogleMLKit/TextRecognitionKorean', '4.0.0'
+  s.dependency 'GoogleMLKit/TextRecognitionKorean', '2.6.0'
 end
 

--- a/text-recognition/RNMLKitTextRecognition.podspec
+++ b/text-recognition/RNMLKitTextRecognition.podspec
@@ -22,14 +22,14 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   # To recognize Latin script
-  s.dependency 'GoogleMLKit/TextRecognition', '2.6.0'
+  s.dependency 'GoogleMLKit/TextRecognition', '4.0.0'
   # To recognize Chinese script
-  s.dependency 'GoogleMLKit/TextRecognitionChinese', '2.6.0'
+  s.dependency 'GoogleMLKit/TextRecognitionChinese', '4.0.0'
   # To recognize Devanagari script
-  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '2.6.0'
+  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '4.0.0'
   # To recognize Japanese script
-  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '2.6.0'
+  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '4.0.0'
   # To recognize Korean script
-  s.dependency 'GoogleMLKit/TextRecognitionKorean', '2.6.0'
+  s.dependency 'GoogleMLKit/TextRecognitionKorean', '4.0.0'
 end
 

--- a/text-recognition/index.d.ts
+++ b/text-recognition/index.d.ts
@@ -62,9 +62,17 @@ interface ITextRecognition {
    * Recognize text in the image
    *
    * @param imageURL The URL/Path of the image to process
+   *
+   * @param language @optional The language to use for non-latin
+   * text recognition. The default is English. Available languages:
+   * - Chinese
+   * - Devanagari
+   * - Japanese
+   * - Korean
+   *
    * @returns Text recognition result
    */
-  recognize: (imageURL: string) => Promise<TextRecognitionResult>;
+  recognize: (imageURL: string, language?: string | null) => Promise<TextRecognitionResult>;
 }
 
 declare const TextRecognition: ITextRecognition;

--- a/text-recognition/index.d.ts
+++ b/text-recognition/index.d.ts
@@ -71,7 +71,7 @@ interface ITextRecognition {
    *
    * @param imageURL The URL/Path of the image to process
    *
-   * @param language @optional The language to use for non-latin
+   * @param script @optional The language to use for non-latin
    * text recognition. The default is set to Latin scripts. Available scripts:
    * - Chinese
    * - Devanagari

--- a/text-recognition/index.d.ts
+++ b/text-recognition/index.d.ts
@@ -57,6 +57,14 @@ export interface TextRecognitionResult {
   blocks: TextBlock[];
 }
 
+export enum TranslateRecognitionScript {
+  LATIN = 'Latin',
+  CHINESE = 'Chinese',
+  DEVANAGARI = 'Devanagari',
+  JAPANESE = 'Japanese',
+  KOREAN = 'Korean',
+}
+
 interface ITextRecognition {
   /**
    * Recognize text in the image
@@ -64,7 +72,7 @@ interface ITextRecognition {
    * @param imageURL The URL/Path of the image to process
    *
    * @param language @optional The language to use for non-latin
-   * text recognition. The default is English. Available languages:
+   * text recognition. The default is set to Latin scripts. Available scripts:
    * - Chinese
    * - Devanagari
    * - Japanese
@@ -72,7 +80,10 @@ interface ITextRecognition {
    *
    * @returns Text recognition result
    */
-  recognize: (imageURL: string, language?: string | null) => Promise<TextRecognitionResult>;
+  recognize: (
+    imageURL: string,
+    script?: TranslateRecognitionScript = TranslateRecognitionScript.LATIN
+  ) => Promise<TextRecognitionResult>;
 }
 
 declare const TextRecognition: ITextRecognition;

--- a/text-recognition/index.d.ts
+++ b/text-recognition/index.d.ts
@@ -57,7 +57,7 @@ export interface TextRecognitionResult {
   blocks: TextBlock[];
 }
 
-export enum TranslateRecognitionScript {
+export enum TextRecognitionScript {
   LATIN = 'Latin',
   CHINESE = 'Chinese',
   DEVANAGARI = 'Devanagari',

--- a/text-recognition/index.d.ts
+++ b/text-recognition/index.d.ts
@@ -71,7 +71,7 @@ interface ITextRecognition {
    *
    * @param imageURL The URL/Path of the image to process
    *
-   * @param script @optional The language to use for non-latin
+   * @param [script] The language to use for non-latin
    * text recognition. The default is set to Latin scripts. Available scripts:
    * - Chinese
    * - Devanagari

--- a/text-recognition/index.js
+++ b/text-recognition/index.js
@@ -6,6 +6,14 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo managed workflow\n';
 
+export const TranslateRecognitionScript = Object.freeze({
+  LATIN: 'Latin',
+  CHINESE: 'Chinese',
+  DEVANAGARI: 'Devanagari',
+  JAPANESE: 'Japanese',
+  KOREAN: 'Korean',
+});
+
 const TextRecognition = NativeModules.TextRecognition
   ? NativeModules.TextRecognition
   : new Proxy(

--- a/text-recognition/index.js
+++ b/text-recognition/index.js
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const LINKING_ERROR =
   `The package '@react-native-ml-kit/text-recognition' doesn't seem to be linked. Make sure: \n\n` +
@@ -25,4 +25,12 @@ const TextRecognition = NativeModules.TextRecognition
       }
     );
 
-export default TextRecognition;
+export default {
+  recognize: (imageURL, script = TextRecognitionScript.LATIN) => {
+    if (Platform.OS === 'ios') {
+      return TextRecognition.recognize(imageURL, script);
+    }
+
+    return TextRecognition.recognize(imageURL);
+  },
+};

--- a/text-recognition/index.js
+++ b/text-recognition/index.js
@@ -6,7 +6,7 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo managed workflow\n';
 
-export const TranslateRecognitionScript = Object.freeze({
+export const TextRecognitionScript = Object.freeze({
   LATIN: 'Latin',
   CHINESE: 'Chinese',
   DEVANAGARI: 'Devanagari',

--- a/text-recognition/ios/TextRecognition.m
+++ b/text-recognition/ios/TextRecognition.m
@@ -3,6 +3,10 @@
 @import MLKitVision.MLKVisionImage;
 @import MLKitTextRecognition;
 @import MLKitTextRecognitionCommon;
+@import MLKitTextRecognitionChinese;
+@import MLKitTextRecognitionJapanese;
+@import MLKitTextRecognitionKorean;
+@import MLKitTextRecognitionDevanagari;
 
 @implementation TextRecognition
 
@@ -75,6 +79,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(recognize: (nonnull NSString*)url
+                  language:(NSString*)language
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -82,8 +87,27 @@ RCT_EXPORT_METHOD(recognize: (nonnull NSString*)url
     NSData *imageData = [NSData dataWithContentsOfURL:_url];
     UIImage *image = [UIImage imageWithData:imageData];
     MLKVisionImage *visionImage = [[MLKVisionImage alloc] initWithImage:image];
-    MLKTextRecognizer *textRecognizer = [MLKTextRecognizer textRecognizer];
+
+    // text recognizer options based on the language params
+    MLKTextRecognizerOptions *options = nil;
+
+    // if the language param isn't specified, we can assume the user requirement is Latin text recognition
+    if (language == nil) {
+        options = [[MLKTextRecognizerOptions alloc] init];
+    } else if ([language isEqualToString:@"Chinese"]) {
+        options = [[MLKChineseTextRecognizerOptions alloc] init];
+    } else if ([language isEqualToString:@"Devanagari"]) {
+        options = [[MLKDevanagariTextRecognizerOptions alloc] init];
+    } else if ([language isEqualToString:@"Japanese"]) {
+        options = [[MLKJapaneseTextRecognizerOptions alloc] init];
+    } else if ([language isEqualToString:@"Korean"]) {
+        options = [[MLKKoreanTextRecognizerOptions alloc] init];
+    } else {
+        return reject(@"Text Recognition", @"Unsupported language", nil);
+    }
     
+    MLKTextRecognizer *textRecognizer = [MLKTextRecognizer textRecognizerWithOptions:options];
+
     [textRecognizer processImage:visionImage
                       completion:^(MLKText *_Nullable _result,
                                    NSError *_Nullable error) {

--- a/text-recognition/ios/TextRecognition.m
+++ b/text-recognition/ios/TextRecognition.m
@@ -79,7 +79,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(recognize: (nonnull NSString*)url
-                  language:(NSString*)language
+                  script:(NSString*)script
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -88,22 +88,22 @@ RCT_EXPORT_METHOD(recognize: (nonnull NSString*)url
     UIImage *image = [UIImage imageWithData:imageData];
     MLKVisionImage *visionImage = [[MLKVisionImage alloc] initWithImage:image];
 
-    // text recognizer options based on the language params
+    // text recognizer options based on the script params
     MLKTextRecognizerOptions *options = nil;
 
     // if the language param isn't specified, we can assume the user requirement is Latin text recognition
-    if (language == nil) {
+    if (script == nil) {
         options = [[MLKTextRecognizerOptions alloc] init];
-    } else if ([language isEqualToString:@"Chinese"]) {
+    } else if ([script isEqualToString:@"Chinese"]) {
         options = [[MLKChineseTextRecognizerOptions alloc] init];
-    } else if ([language isEqualToString:@"Devanagari"]) {
+    } else if ([script isEqualToString:@"Devanagari"]) {
         options = [[MLKDevanagariTextRecognizerOptions alloc] init];
-    } else if ([language isEqualToString:@"Japanese"]) {
+    } else if ([script isEqualToString:@"Japanese"]) {
         options = [[MLKJapaneseTextRecognizerOptions alloc] init];
-    } else if ([language isEqualToString:@"Korean"]) {
+    } else if ([script isEqualToString:@"Korean"]) {
         options = [[MLKKoreanTextRecognizerOptions alloc] init];
     } else {
-        return reject(@"Text Recognition", @"Unsupported language", nil);
+        return reject(@"Text Recognition", @"Unsupported script", nil);
     }
     
     MLKTextRecognizer *textRecognizer = [MLKTextRecognizer textRecognizerWithOptions:options];

--- a/text-recognition/ios/TextRecognition.m
+++ b/text-recognition/ios/TextRecognition.m
@@ -92,7 +92,7 @@ RCT_EXPORT_METHOD(recognize: (nonnull NSString*)url
     MLKTextRecognizerOptions *options = nil;
 
     // if the language param isn't specified, we can assume the user requirement is Latin text recognition
-    if (script == nil) {
+    if (script == nil || [script isEqualToString:@"Latin"]) {
         options = [[MLKTextRecognizerOptions alloc] init];
     } else if ([script isEqualToString:@"Chinese"]) {
         options = [[MLKChineseTextRecognizerOptions alloc] init];


### PR DESCRIPTION
Closes #27

## What does this PR do?

This PR adds official text-recognition support for:
```
GoogleMLKit/TextRecognitionChinese
GoogleMLKit/TextRecognitionDevanagari
GoogleMLKit/TextRecognitionJapanese
GoogleMLKit/TextRecognitionKorean
```

## How to use

```tsx
const result = await TextRecognition.recognize(imagePath) // Latin text-recognition
...
const result = await TextRecognition.recognize(imagePath, 'Chinese') // Chinese text-recognition
...
const result = await TextRecognition.recognize(imagePath, 'Devanagari') // Devanagari text-recognition
...
const result = await TextRecognition.recognize(imagePath, 'Japanese') // Japanese text-recognition
...
const result = await TextRecognition.recognize(imagePath, 'Korean') // Korean text-recognition
```

## Results:

**Japanese and Devanagari**
<img width="420" alt="Screenshot 2023-04-04 at 7 36 41 PM" src="https://user-images.githubusercontent.com/6411509/229947177-293c5da3-97b2-417e-b54b-b058ebfe049d.png">

**Chinese**
<img width="420" alt="Screenshot 2023-04-04 at 7 34 38 PM" src="https://user-images.githubusercontent.com/6411509/229947180-b83a0bb6-c6a7-4179-8833-9798263c7d98.png">

**Korean**
<img width="420" alt="Screenshot 2023-04-04 at 7 33 41 PM" src="https://user-images.githubusercontent.com/6411509/229947184-a1cb2716-7762-4f2b-8f25-664809dcb75f.png">


This is my first PR here! I will be the first to admit that Objective-C is not my strongest language, so I welcome any and all feedback! I would love for someone to pull this branch down and take it for a spin. My initial testing yielded some good results but would love someone to double-check my work and give me a sanity check 😄
