### PR TITLE
Update the iOS deployment target in podspec file to match the GoogleMLKit requirements

### DIFF
--- a/text-recognition/RNMLKitTextRecognition.podspec
+++ b/text-recognition/RNMLKitTextRecognition.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   # optional - use expanded license entry instead:
   # s.license    = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "Ahmed Mahmoud" => "a7med.mahmoud2004@gmail.com" }
-  s.platforms    = { :ios => "9.0" }
+  s.platforms    = { :ios => "15.5" }
   s.source       = { :git => "https://github.com/a7med-mahmoud/react-native-ml-kit.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift}"


### PR DESCRIPTION
New projects using this module are failing while running `pod install`.

> ⚠️  Something went wrong running `pod install` in the `ios` directory.
> Command `pod install` failed.
> └─ Cause: CocoaPods could not find compatible versions for pod "GoogleMLKit/TextRecognition":
>   In Podfile:
>     RNMLKitTextRecognition (from `../node_modules/@react-native-ml-kit/text-recognition`) was resolved to 1.6.0, which depends on
>       GoogleMLKit/TextRecognition (= 8.0.0)
> 
> Specs satisfying the `GoogleMLKit/TextRecognition (= 8.0.0)` dependency were found, but they required a higher minimum deployment target.
> 
> pod install --repo-update --ansi exited with non-zero code: 1". what in my project is causing this?

This is because in Google's ML Kit release notes, GoogleMLKit 8.0.0 requires iOS 15.5.0 as the minimum deployment target. This requirement was introduced in the September 30, 2024 release. Hence, I have updated the existing `9.0` minimum target to `15.5`. This change no longer causes the builds to fail in the new projects that are using it.